### PR TITLE
[ FIX ] OT198-30-FIX Add properties at welcomeEmail template

### DIFF
--- a/services/sendgrid.js
+++ b/services/sendgrid.js
@@ -1,4 +1,5 @@
 const sgMail = require('@sendgrid/mail')
+const { html } = require('../templates/welcomeEmail')
 
 sgMail.setApiKey(process.env.SENDGRID_API_KEY)
 const sendWelcomeEmail = async (email) => {
@@ -7,7 +8,7 @@ const sendWelcomeEmail = async (email) => {
       to: email,
       from: process.env.SENDGRID_EMAIL,
       subject: 'Welcome to the app',
-      text: 'Welcome to the app, enjoy!',
+      html: html('Titulo dinamico', 'Texto de mail dinamino', 'Datos de contacto dinamicos'),
     }
     await sgMail.send(msg)
   } catch (error) {

--- a/templates/welcomeEmail.js
+++ b/templates/welcomeEmail.js
@@ -1,4 +1,4 @@
-const html = `<!doctype html>
+exports.html = (title, emailText, contactInfo) => `<!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
   xmlns:o="urn:schemas-microsoft-com:office:office">
 
@@ -298,9 +298,9 @@ const html = `<!doctype html>
                       <div
                         style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:11px;line-height:1.5;text-align:left;color:#000000;">
                         <p style="text-align: center;"><span
-                            style="font-size: 24px;"><strong>T&iacute;tulo</strong></span></p>
+                            style="font-size: 24px;"><strong>${title}</strong></span></p>
                         <p style="text-align: center;">&nbsp;</p>
-                        <p style="text-align: center;"><span style="font-size: 16px;">Texto del email</span></p>
+                        <p style="text-align: center;"><span style="font-size: 16px;">${emailText}</span></p>
                       </div>
 
                     </td>
@@ -325,7 +325,7 @@ const html = `<!doctype html>
 
                       <div
                         style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:11px;line-height:1.5;text-align:left;color:#000000;">
-                        <p style="text-align: center;">Datos de contacto de ONG</p>
+                        <p style="text-align: center;">${contactInfo}</p>
                       </div>
 
                     </td>
@@ -405,12 +405,3 @@ const html = `<!doctype html>
 </body>
 
 </html>`
-
-module.exports = {
-  templateEmail: (to, from, subject = 'Welcome! Thanks for you for subscribe') => ({
-    to,
-    from,
-    subject,
-    html,
-  }),
-}


### PR DESCRIPTION
[OT198-30-FIX](https://alkemy-labs.atlassian.net/browse/OT198-30)

## Description

AS user
I WANT TO receive a welcome email when registering
SO THAT I can make sure the registration happened correctly. 

### Acceptance criteria

When the user registers on the site, a welcome email will be sent. It must contain the logo and name of the Organization, a welcome text and contact information.

## Evidence

- Template email sent with properties

![Screenshot_2](https://user-images.githubusercontent.com/72532638/171285157-75c58394-8846-4629-8792-e44fbbd7efcf.png)
