### PR TITLE
[ FIX ]- OT198-44 -  FIX Add Middleware at Update Categories Endpoint

### DIFF
--- a/routes/categories.js
+++ b/routes/categories.js
@@ -19,6 +19,6 @@ router.post('/', validateSchema(categorySchema), post)
 router.delete('/:id', destroy)
 
 // edit category
-router.put('/:id', update)
+router.put('/:id', validateSchema(categorySchema), update)
 
 module.exports = router


### PR DESCRIPTION
[OT198-44](https://alkemy-labs.atlassian.net/jira/software/c/projects/OT198/boards/278?modal=detail&selectedIssue=OT198-44)

## Description

AS admin user
I WANT to modify an existing category
TO keep the information updated

Criteria of acceptance:
PUT /categories/:id - It must validate that the category exists and update it, otherwise return an error

## NEW Evidence

GET /categories

<img width="722" alt="GET - allCategories" src="https://user-images.githubusercontent.com/86156941/171287641-0fcec0a6-31fe-46d1-8926-59bba472dafd.png">

PUT /categories/1

<img width="638" alt="PUT- category edit" src="https://user-images.githubusercontent.com/86156941/171287697-6323ddc3-db7a-44f9-ab38-755a95fa63a9.png">

GET /categories - CATEGORY EDIT

<img width="483" alt="Captura de Pantalla 2022-05-31 a la(s) 18 34 32" src="https://user-images.githubusercontent.com/86156941/171288404-95bf1d61-0d1a-420b-a96c-a91cadca91e7.png">


PUT /categories/1 - empty value at "name" 

<img width="734" alt="PUT- error name" src="https://user-images.githubusercontent.com/86156941/171287786-d67d213c-1271-420b-8ed1-6ef45edcd1b2.png">

PUT /categories/77

<img width="530" alt="PUT NOT FOUND" src="https://user-images.githubusercontent.com/86156941/171287845-6922142a-72e2-4f5c-82b4-d028892f1432.png">






