### PR TITLE
[ERRORHANDLER] - Add node env develoment to show more errors when dev

### DIFF
--- a/middlewares/errorHandler.js
+++ b/middlewares/errorHandler.js
@@ -5,7 +5,13 @@ const errorConverter = (err, req, res, next) => {
   let error = err
   if (!(error instanceof ApiError)) {
     const statusCode = error.statusCode || httpStatus.INTERNAL_SERVER_ERROR
-    const message = error.statusCode === httpStatus.NOT_FOUND ? 'Not Found' : 'Internal server error' // para no mostrar informacion de la base de datos (puede mejorarse)
+    let message
+    if (process.env.NODE_ENV === 'development') {
+      message = error.message || 'Internal server error'
+    } else {
+      message = error.statusCode === httpStatus.NOT_FOUND ? 'Not Found' : 'Internal server error'
+    }
+
     error = new ApiError(statusCode, message, false)
   }
   next(error)


### PR DESCRIPTION
## Usage
- Add NODE_ENV=development to .env
![image](https://user-images.githubusercontent.com/88128116/171967045-5553a58b-1090-4d30-9c2d-761cfccef01e.png)

### Evidence
- NODE_ENV = development - POST /auth/register with db dropped
![image](https://user-images.githubusercontent.com/88128116/171966878-95072d7d-e800-445d-8538-2242a4b30189.png)
- NODE_ENV  != development - POST /auth/register with db dropped
![image](https://user-images.githubusercontent.com/88128116/171966953-ffa38227-6d20-4fc8-abbe-1bf867311843.png)

