### PR TITLE
[ENDPOINT] - OT198-62 - Add Slides to public endpoint 

### DIFF
--- a/controllers/organization.js
+++ b/controllers/organization.js
@@ -1,21 +1,22 @@
 const createHttpError = require('http-errors')
 const { endpointResponse } = require('../helpers/success')
 const { catchAsync } = require('../helpers/catchAsync')
-const services = require('../services/organization')
 
-const { listOrganization, updateOrganization } = services
+const { listOrganization, updateOrganization } = require('../services/organization')
+const { listSlideByOrder } = require('../services/slide')
 
 // find all Organization function
 module.exports = {
   list: catchAsync(async (req, res, next) => {
     try {
       const publicData = await listOrganization()
+      const publicSlide = await listSlideByOrder()
       endpointResponse({
         res,
         code: 200,
         status: true,
         message: 'Organizations public data retrieved successfully',
-        body: publicData,
+        body: [publicData, publicSlide],
       })
     } catch (error) {
       const httpError = createHttpError(

--- a/services/slide.js
+++ b/services/slide.js
@@ -10,6 +10,14 @@ const listSlide = async () => {
   }
 }
 
+const listSlideByOrder = async () => {
+  try {
+    return await Slide.findAll({ order: [['order', 'ASC']] })
+  } catch (error) {
+    throw new Error(error)
+  }
+}
+
 const listSlideById = async (id) => {
   try {
     const slide = await Slide.findByPk(id)
@@ -20,5 +28,7 @@ const listSlideById = async (id) => {
 }
 
 module.exports = {
-  listSlide, listSlideById,
+  listSlide,
+  listSlideByOrder,
+  listSlideById,
 }


### PR DESCRIPTION
[OT198-62](https://alkemy-labs.atlassian.net/jira/software/c/projects/OT198/boards/278?modal=detail&selectedIssue=OT198-62)

## Description 

AS user
I WANT to see Slides when I enter the page
TO be more informed about them

Criteria of acceptance:

In the public data endpoint of the Organization, the list of Slides ordered by the "order" field must be added.

The Slides will be those belonging to the Organization, based on the organization_id field that should correspond to the Organization that is being returned

### Evidence 

GET /organization/public

<img width="748" alt="GET :org:public - res " src="https://user-images.githubusercontent.com/86156941/172180201-48fceede-8fa7-43b3-92b0-e9ecea879ea8.png">

Order 
<img width="1227" alt="req :org:public - order" src="https://user-images.githubusercontent.com/86156941/172180311-3ad597b2-ff97-41bf-ae8a-589e8a530895.png">


