### PR TITLE
[IMPROVEMENT] - Small improvement to schema validation middleware

### DIFF
--- a/middlewares/validateErrors.js
+++ b/middlewares/validateErrors.js
@@ -1,7 +1,7 @@
 const { validationResult } = require('express-validator')
 const util = require('util')
 const fs = require('fs')
-const ApiError = require('../helpers/ApiError')
+const httpStatus = require('../helpers/httpStatus')
 const { catchAsync } = require('../helpers/catchAsync')
 
 const unlinkFile = util.promisify(fs.unlink)
@@ -13,7 +13,10 @@ module.exports = {
     const errors = validationResult(req)
     if (!errors.isEmpty()) {
       if (req.file) await unlinkFile(req.file.path)
-      throw new ApiError(400, errors.errors.map((error) => error.msg).join(', '))
+      return res.status(httpStatus.BAD_REQUEST).json({
+        status: false,
+        errors: errors.array(),
+      })
     }
     return next()
   }),

--- a/middlewares/validateErrors.js
+++ b/middlewares/validateErrors.js
@@ -14,6 +14,7 @@ module.exports = {
     if (!errors.isEmpty()) {
       if (req.file) await unlinkFile(req.file.path)
       return res.status(httpStatus.BAD_REQUEST).json({
+        code: httpStatus.BAD_REQUEST,
         status: false,
         errors: errors.array(),
       })


### PR DESCRIPTION
## Description

Changes to the middleware that validates the schemas so that when there are errors it returns an error array and not a concatenated string
- Current return:
![image](https://user-images.githubusercontent.com/88128116/172193016-b228e63d-66cc-48dc-a217-309a25896a8c.png)

- After this change
![image](https://user-images.githubusercontent.com/88128116/172193440-b9e22744-7d15-422c-a9a0-d9ba6bf799f2.png)
