### PR TITLE
[ENDPOINT] - OT198-62 -  Add Slides to public endpoint 

### DIFF
--- a/controllers/organization.js
+++ b/controllers/organization.js
@@ -1,21 +1,21 @@
 const createHttpError = require('http-errors')
 const { endpointResponse } = require('../helpers/success')
 const { catchAsync } = require('../helpers/catchAsync')
-const services = require('../services/organization')
-
-const { listOrganization, updateOrganization } = services
+const { listOrganization, updateOrganization } = require('../services/organization')
+const { listSlideByOrder } = require('../services/slide')
 
 // find all Organization function
 module.exports = {
   list: catchAsync(async (req, res, next) => {
     try {
       const publicData = await listOrganization()
+      const publicSlide = await listSlideByOrder()
       endpointResponse({
         res,
         code: 200,
         status: true,
         message: 'Organizations public data retrieved successfully',
-        body: publicData,
+        body: [publicData, publicSlide],
       })
     } catch (error) {
       const httpError = createHttpError(

--- a/services/slide.js
+++ b/services/slide.js
@@ -15,6 +15,13 @@ module.exports = {
       throw new Error(error)
     }
   },
+  listSlideByOrder: async () => {
+    try {
+      return await Slide.findAll({ order: [['order', 'ASC']] })
+    } catch (error) {
+      throw new ApiError(httpStatus.NOT_FOUND, 'Slides not found')
+    }
+  },
   listSlideById: async (id) => {
     try {
       const slide = await Slide.findByPk(id)


### PR DESCRIPTION
[OT198-62](https://alkemy-labs.atlassian.net/jira/software/c/projects/OT198/boards/278?modal=detail&selectedIssue=OT198-62)

##DESCRIPTION

AS user
I WANT to see Slides when I enter the page
TO be more informed about them

Criteria of acceptance:

In the public data endpoint of the Organization, the list of Slides ordered by the "order" field must be added.

The Slides will be those belonging to the Organization, based on the organization_id field that should correspond to the Organization that is being returned

###EVIDENCE

GET /ORGANIZATION/PUBLIC 

<img width="748" alt="GET :org:public - res " src="https://user-images.githubusercontent.com/86156941/172229345-23254eb1-4dca-4756-90d1-072d233b60b2.png">

ORDER:

<img width="748" alt="GET :org:public - res " src="https://user-images.githubusercontent.com/86156941/172229405-93c56dfe-7ad1-492e-a8b7-24d9048fbe90.png">







