### PR TITLE
[ENDPOINT] - List new comments by newId - OT198-84

### DIFF
--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -1,6 +1,6 @@
 const { catchAsync } = require('../helpers/catchAsync')
 const { endpointResponse } = require('../helpers/success')
-const { listComments } = require('../services/comments')
+const { listComments, listNewsCommentsService } = require('../services/comments')
 
 module.exports = {
   list: catchAsync(async (req, res) => {
@@ -11,6 +11,17 @@ module.exports = {
       status: true,
       message: 'Comments listed',
       body: comments,
+    })
+  }),
+  listNewsComments: catchAsync(async (req, res) => {
+    const { id } = req.params
+    const newsComments = await listNewsCommentsService(id)
+    endpointResponse({
+      res,
+      code: 200,
+      status: true,
+      message: `Comments of new with id ${id} listed`,
+      body: newsComments,
     })
   }),
 }

--- a/routes/news.js
+++ b/routes/news.js
@@ -9,10 +9,14 @@ const {
 } = require('../controllers/news')
 const { auth } = require('../middlewares/auth')
 const { isAdmin } = require('../middlewares/isAdmin')
+const { listNewsComments } = require('../controllers/comments')
 
 router.get('/:id', listNews)
 router.post('/', validateSchema(newSchema), post)
 router.put('/:id', validateSchema(newSchema), update)
 router.delete('/:id', auth, isAdmin, destroy)
+
+// get news comments
+router.get('/:id/comments', auth, listNewsComments)
 
 module.exports = router

--- a/services/comments.js
+++ b/services/comments.js
@@ -1,4 +1,4 @@
-const { Comment } = require('../database/models')
+const { Comment, User, New } = require('../database/models')
 const ApiError = require('../helpers/ApiError')
 const httpStatus = require('../helpers/httpStatus')
 
@@ -13,5 +13,59 @@ module.exports = {
     } catch (error) {
       throw new ApiError(httpStatus.NOT_FOUND, error.parent.code)
     }
+  },
+  /**
+   * @param {number} id the id of the new
+   * @returns {Promise<Comment[]>} the comments of the new
+   * @throws {ApiError} if the new does not exist
+   * @description Get comments of a news
+   * @example
+   * GET localhost:3000/news/:id/comments
+   * {
+   *  "comments": [
+   *   {
+   *    "id": 1,
+   *    "UserId": 1,
+   *    "body": "This is a comment",
+   *    "NewId": 1,
+   *    "createdAt": "2020-05-05T15:00:00.000Z",
+   *    "updatedAt": "2020-05-05T15:00:00.000Z",
+   *    "User": {
+   *        "firstName": "John",
+   *        "lastName": "Doe",
+   *     },
+   * {
+   *    "id": 2,
+   *    "UserId": 1,
+   *    "body": "This is a comment 2",
+   *    "NewId": 1
+   *    "createdAt": "2020-05-05T15:00:00.000Z",
+   *    "updatedAt": "2020-05-05T15:00:00.000Z",
+   *    "User": {
+   *        "firstName": "Yoda",
+   *        "lastName": "Doe",
+   *    }
+   * ]
+   * }
+   * */
+  listNewsCommentsService: async (id) => {
+    // check if new with id exists
+    if (!(await New.findByPk(id))) {
+      throw new ApiError(httpStatus.NOT_FOUND, `There is no news with id ${id}`)
+    }
+
+    // get comments of new with id
+    const comments = await Comment.findAll({
+      where: {
+        newId: id,
+      },
+      include: [
+        {
+          model: User,
+          attributes: ['firstName', 'lastName'],
+        },
+      ],
+    })
+    return { comments }
   },
 }

--- a/services/comments.js
+++ b/services/comments.js
@@ -59,6 +59,7 @@ module.exports = {
       where: {
         newId: id,
       },
+      order: [['createdAt', 'DESC']],
       include: [
         {
           model: User,


### PR DESCRIPTION
[OT198-84](https://alkemy-labs.atlassian.net/browse/OT198-84)
## Description

AS user
I WANT to view the Comments of a post
TO get organized information

Criteria of acceptance:
GET /new/:id/comments - Will return all Comments belonging to a post
### Evidence
- GET /new/1/comments happy path new id = 1
![image](https://user-images.githubusercontent.com/88128116/172674117-1457fa03-ccc3-4ef5-aa25-6f39f04acc97.png)
- GET /new/2/comments happy path new id = 2
![image](https://user-images.githubusercontent.com/88128116/172674283-a5cb7627-2910-4949-8019-808420450ba7.png)
- GET /new/3/comments new id = 3, this new does not exist in the db
![image](https://user-images.githubusercontent.com/88128116/172674502-17b40e20-2ba5-48b4-8324-ef70a434c9b2.png)
- If new has no comments it returns an empty array
![image](https://user-images.githubusercontent.com/88128116/172674744-12ff91b7-d6f8-4dce-ada5-f32ecea05411.png)
