### PR TITLE
[PAGINATION] - Add pagination to members - OT198-88

### DIFF
--- a/controllers/members.js
+++ b/controllers/members.js
@@ -2,16 +2,21 @@ const httpStatus = require('../helpers/httpStatus')
 const { endpointResponse } = require('../helpers/success')
 const { catchAsync } = require('../helpers/catchAsync')
 const { listMembers, createMember } = require('../services/members')
+const { calculatePagination } = require('../utils/pagination')
 
 module.exports = {
   list: catchAsync(async (req, res) => {
-    const members = await listMembers()
+    req.query.page = req.query.page || 1
+    const members = await listMembers(req.query.page)
     endpointResponse({
       res,
       code: httpStatus.OK,
       status: true,
       message: 'Members successfully retrieved',
-      body: members,
+      body: {
+        ...calculatePagination(req.query.page, members.count),
+        members: members.rows,
+      },
     })
   }),
   post: catchAsync(async (req, res) => {

--- a/services/members.js
+++ b/services/members.js
@@ -10,13 +10,13 @@ const db = require('../database/models')
 const { Member } = db
 
 module.exports = {
-  listMembers: async () => {
-    try {
-      const allMembers = await Member.findAll()
-      return allMembers
-    } catch (error) {
-      throw new ApiError(httpStatus.NOT_FOUND, error.parent.code)
-    }
+  listMembers: async (page) => {
+    const allMembers = await Member.findAndCountAll({
+      limit: 10,
+      offset: 10 * (page - 1),
+      order: [['createdAt', 'DESC']],
+    })
+    return allMembers
   },
   createMember: async (req) => {
     try {

--- a/utils/pagination.js
+++ b/utils/pagination.js
@@ -1,0 +1,25 @@
+const baseURL = process.env.BASE_URL
+  ? `${process.env.BASE_URL}/members?page=`
+  : 'http://localhost:3000/members?page='
+
+module.exports = {
+  /**
+   * Calculate pagination
+   *
+   * @param {number} page number of the page
+   * @param {number} total entity count
+   * @returns {Object} pagination object
+   * */
+  calculatePagination: (page, total) => {
+    const currentPage = parseInt(page, 10)
+    const lastPage = Math.ceil(total / 10)
+    const prevPage = currentPage === 1 ? undefined : currentPage - 1
+    const nextPage = lastPage < currentPage + 1 ? undefined : currentPage + 1
+    return {
+      page: baseURL + currentPage,
+      nextPage: nextPage ? baseURL + nextPage : undefined,
+      prevPage: prevPage ? baseURL + prevPage : undefined,
+      lastPage: baseURL + lastPage,
+    }
+  },
+}


### PR DESCRIPTION
[OT198-88](https://alkemy-labs.atlassian.net/browse/OT198-87)
## Description 
AS user
I WANT to view the results of Paginated Members
TO increase response speed

Criteria of acceptance:
When the request to list is made, the results should be paginated by 10. In the response, the results and the urls for the previous and next page (if applicable) should be displayed. The current page is obtained from the query parameter ?page

### Evidence
url = secret, if not secret = localhost

- GET /members?page=1 
![image](https://user-images.githubusercontent.com/88128116/172692428-391536d8-b24f-49d1-b9ef-76af55b6efb3.png)
- GET /members?page=2
![image](https://user-images.githubusercontent.com/88128116/172692292-b9861ca5-3e6d-4182-b1f0-973ac91d9b91.png)
- GET /members?page=7 last page in this case
![image](https://user-images.githubusercontent.com/88128116/172692526-d4ea3c8b-4384-48b0-b23d-d9c84071de52.png)
