### PR TITLE
[ENDPOINT] - Endpoint api/docs - Swagger - OT198-89

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "multer": "^1.4.5-lts.1",
     "mysql2": "^2.2.3",
     "sequelize": "^6.3.5",
-    "sequelize-cli": "6.2.0"
+    "sequelize-cli": "6.2.0",
+    "swagger-jsdoc": "^6.2.1",
+    "swagger-ui-express": "^4.4.0"
   },
   "devDependencies": {
     "chai": "^4.3.4",

--- a/routes/index.js
+++ b/routes/index.js
@@ -13,6 +13,7 @@ const testimonialRouter = require('./testimonial')
 const contactsRouter = require('./contacts')
 const commentsRouter = require('./comments')
 const membersRouter = require('./members')
+const swaggerRouter = require('./swagger')
 
 const router = express.Router()
 
@@ -58,5 +59,7 @@ router.use('/testimonials', testimonialRouter)
 router.use('/comments', commentsRouter)
 // members routes
 router.use('/members', membersRouter)
+// swagger routes
+router.use('/api/docs', swaggerRouter)
 
 module.exports = router

--- a/routes/swagger.js
+++ b/routes/swagger.js
@@ -1,0 +1,9 @@
+const router = require('express').Router()
+const swaggerJsdoc = require('swagger-jsdoc')
+const swaggerUi = require('swagger-ui-express')
+const swaggerDocument = require('../swagger')
+
+const specs = swaggerJsdoc(swaggerDocument)
+router.use('/', swaggerUi.serve)
+router.get('/', swaggerUi.setup(specs))
+module.exports = router

--- a/swagger/basicInfo.js
+++ b/swagger/basicInfo.js
@@ -1,0 +1,8 @@
+module.exports = {
+  openapi: '3.0.3',
+  info: {
+    title: 'AlkemyONG',
+    description: 'Server 198 - Node.js',
+    version: '1.0.0',
+  },
+}

--- a/swagger/index.js
+++ b/swagger/index.js
@@ -1,0 +1,10 @@
+const basicInfo = require('./basicInfo')
+const server = require('./server')
+
+module.exports = {
+  definition: {
+    ...basicInfo,
+    ...server,
+  },
+  apis: ['./routes/*.js'],
+}

--- a/swagger/server.js
+++ b/swagger/server.js
@@ -1,0 +1,19 @@
+require('dotenv').config()
+
+let server
+
+if (process.env.NODE_ENV === 'production') {
+  server = {
+    url: `${process.env.APP_URL_PRODUCTION}`,
+    description: 'Production server',
+  }
+} else {
+  server = {
+    url: `http://localhost:${process.env.PORT}`,
+    description: 'Local server',
+  }
+}
+
+module.exports = {
+  servers: [server],
+}


### PR DESCRIPTION
[OT198-89](https://alkemy-labs.atlassian.net/browse/OT198-89) 

## Description 

AS a developer
I WANT to have a documentation of the API endpoints
TO have references of the operation of the system

Criteria of acceptance:

The Swagger library must be implemented to document the different endpoints of the project. When entering the /api/docs endpoint, the layout should be displayed. Additionally, add the possibility to implement the different schemas based on the method Comments of each controller.

## Evidence 
![image](https://user-images.githubusercontent.com/81152540/173069671-1aa5d044-bbf4-4fa8-abf1-491ec1c49c0a.png)

 