### PR TITLE
[ENDPOINT] OT198-83 delete comment controller, routes and service

### DIFF
--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -1,6 +1,6 @@
 const { catchAsync } = require('../helpers/catchAsync')
 const { endpointResponse } = require('../helpers/success')
-const { listComments } = require('../services/comments')
+const { listComments, deleteComment } = require('../services/comments')
 
 module.exports = {
   list: catchAsync(async (req, res) => {
@@ -11,6 +11,16 @@ module.exports = {
       status: true,
       message: 'Comments listed',
       body: comments,
+    })
+  }),
+  destroy: catchAsync(async (req, res) => {
+    const { id } = req.params
+    await deleteComment(id, req)
+    return endpointResponse({
+      res,
+      code: 200,
+      status: true,
+      message: 'Comment deleted',
     })
   }),
 }

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -1,8 +1,11 @@
 const router = require('express').Router()
-const { list } = require('../controllers/comments')
+const { list, destroy } = require('../controllers/comments')
 const { auth } = require('../middlewares/auth')
 const { isAdmin } = require('../middlewares/isAdmin')
+// const { ownershipValidate } = require('../middlewares/ownership')
 
 router.get('/', auth, isAdmin, list)
+// delete comments
+router.delete('/:id', auth, destroy)
 
 module.exports = router

--- a/services/comments.js
+++ b/services/comments.js
@@ -1,6 +1,7 @@
 const { Comment } = require('../database/models')
 const ApiError = require('../helpers/ApiError')
 const httpStatus = require('../helpers/httpStatus')
+const { decodeToken } = require('../middlewares/jwt')
 
 module.exports = {
   listComments: async () => {
@@ -13,5 +14,17 @@ module.exports = {
     } catch (error) {
       throw new ApiError(httpStatus.NOT_FOUND, error.parent.code)
     }
+  },
+  deleteComment: async (id, req) => {
+    const comment = await Comment.findByPk(id)
+    if (!comment) {
+      throw new ApiError(httpStatus.NOT_FOUND, 'Comment not found')
+    }
+    const user = decodeToken(req)
+    if (user.roleId === 1 || user.id === comment.userId) {
+      await comment.destroy()
+      return true
+    }
+    throw new ApiError(httpStatus.FORBIDDEN, 'You are not allowed to do this')
   },
 }


### PR DESCRIPTION
Descripción

COMO usuario
QUIERO borrar un comentario
PARA moderar el contenido

Criterios de aceptación:
DELETE /comments/:id - Deberá validar la existencia del comentario. Solamente podrán eliminar un comentario el usuario creador del mismo o un administrador
comment not found
![comment not found](https://user-images.githubusercontent.com/88246144/173144638-c5791283-4123-4871-b91a-d6bc8a071666.jpg)
delete comment owner
![delete comment ownership](https://user-images.githubusercontent.com/88246144/173144663-7dbc1b51-65f3-48c4-a65a-3b01d73d453b.jpg)
delete comment not owner
![delete comment not ownership2](https://user-images.githubusercontent.com/88246144/173145697-a2b1834f-e35e-41f5-8c68-d2b6f19b322e.jpg)



