### PR TITLE
[ PAGINATION ] OT198-86 Add News Pagination

### DIFF
--- a/controllers/news.js
+++ b/controllers/news.js
@@ -8,6 +8,7 @@ const { calculatePagination } = require('../utils/pagination')
 
 module.exports = {
   list: catchAsync(async (req, res) => {
+    const resource = req.baseUrl
     req.query.page = req.query.page || 1
     const news = await listNews(req.query.page)
     endpointResponse({
@@ -16,7 +17,7 @@ module.exports = {
       status: true,
       message: 'successfully retrieved',
       body: {
-        ...calculatePagination(req.query.page, news.count),
+        ...calculatePagination(req.query.page, news.count, resource),
         members: news.rows,
       },
     })

--- a/controllers/news.js
+++ b/controllers/news.js
@@ -2,11 +2,26 @@ const { catchAsync } = require('../helpers/catchAsync')
 const { endpointResponse } = require('../helpers/success')
 const httpStatus = require('../helpers/httpStatus')
 const {
-  getNewById, createNew, updateNew, deleteNew,
+  getNewById, createNew, updateNew, deleteNew, listNews,
 } = require('../services/news')
+const { calculatePagination } = require('../utils/pagination')
 
 module.exports = {
   list: catchAsync(async (req, res) => {
+    req.query.page = req.query.page || 1
+    const news = await listNews(req.query.page)
+    endpointResponse({
+      res,
+      code: httpStatus.OK,
+      status: true,
+      message: 'successfully retrieved',
+      body: {
+        ...calculatePagination(req.query.page, news.count),
+        members: news.rows,
+      },
+    })
+  }),
+  listNew: catchAsync(async (req, res) => {
     const { id } = req.params
     const result = await getNewById(id)
     endpointResponse({

--- a/routes/news.js
+++ b/routes/news.js
@@ -5,13 +5,14 @@ const router = new express.Router()
 const { validateSchema } = require('../middlewares/validateErrors')
 const newSchema = require('../schemas/new')
 const {
-  post, list, update, destroy,
+  post, listNew, update, destroy, list,
 } = require('../controllers/news')
 const { auth } = require('../middlewares/auth')
 const { isAdmin } = require('../middlewares/isAdmin')
 const { listNewsComments } = require('../controllers/comments')
 
-router.get('/:id', list)
+router.get('/', list)
+router.get('/:id', listNew)
 router.post('/', auth, isAdmin, validateSchema(newSchema), post)
 router.put('/:id', auth, isAdmin, validateSchema(newSchema), update)
 router.delete('/:id', auth, isAdmin, destroy)

--- a/services/news.js
+++ b/services/news.js
@@ -3,6 +3,14 @@ const ApiError = require('../helpers/ApiError')
 const httpStatus = require('../helpers/httpStatus')
 
 module.exports = {
+  listNews: async (page) => {
+    const allNews = await New.findAndCountAll({
+      limit: 10,
+      offset: 10 * (page - 1),
+      order: [['createdAt', 'DESC']],
+    })
+    return allNews
+  },
   getNewById: async (id) => {
     const result = await New.findByPk(id)
     if (!result) throw new ApiError(httpStatus.NOT_FOUND, 'New not found')

--- a/utils/pagination.js
+++ b/utils/pagination.js
@@ -1,6 +1,8 @@
+const port = process.env.PORT || 3000
+
 const baseURL = process.env.BASE_URL
   ? `${process.env.BASE_URL}`
-  : 'http://localhost:3000'
+  : `http://localhost:${port}`
 
 const stringPage = '?page='
 


### PR DESCRIPTION
[OT198-86](https://alkemy-labs.atlassian.net/browse/OT198-86)

## Description

AS user
I WANT to view the results of Paginated News
SO THAT I can increase response speed

### Acceptance criteria

When the request to list is made, the results should be paginated by 10. In the response, the results and the urls for the previous and next page (if applicable) should be shown. The current page will be obtained from the query parameter ?page.

## Evidence

![Screenshot_1](https://user-images.githubusercontent.com/72532638/173675327-600c49f5-6dbc-4c87-962c-2c5486c3f518.png)

![Screenshot_2](https://user-images.githubusercontent.com/72532638/173675347-63b7fdf1-f197-4430-a0af-440c00c8d860.png)

![Screenshot_3](https://user-images.githubusercontent.com/72532638/173675367-d5e99473-1f93-4908-9f4c-9704aeb3760e.png)

