### PR TITLE
[ PAGINATION ] - OT198-88 - Add Pagination to Testimonials 

### DIFF
--- a/controllers/testimonial.js
+++ b/controllers/testimonial.js
@@ -2,12 +2,23 @@ const httpStatus = require('../helpers/httpStatus')
 const { catchAsync } = require('../helpers/catchAsync')
 const { endpointResponse } = require('../helpers/success')
 const {
+  listTestimonial,
   createTestimonial,
   updateTestimonial,
   deleteTestimonial,
 } = require('../services/testimonial')
 
 module.exports = {
+  list: catchAsync(async (req, res) => {
+    const testimonials = await listTestimonial()
+    return endpointResponse({
+      res,
+      code: httpStatus.OK,
+      status: true,
+      messege: 'Testimonials found',
+      body: testimonials,
+    })
+  }),
   post: catchAsync(async (req, res) => {
     const testimonialCreated = await createTestimonial(req)
     return endpointResponse({

--- a/controllers/testimonial.js
+++ b/controllers/testimonial.js
@@ -7,16 +7,22 @@ const {
   updateTestimonial,
   deleteTestimonial,
 } = require('../services/testimonial')
+const { calculatePagination } = require('../utils/pagination')
 
 module.exports = {
   list: catchAsync(async (req, res) => {
-    const testimonials = await listTestimonial()
+    const resource = req.baseUrl
+    req.query.page = req.query.page || 1
+    const testimonials = await listTestimonial(req.query.page)
     return endpointResponse({
       res,
       code: httpStatus.OK,
       status: true,
       message: 'Testimonials found',
-      body: testimonials,
+      body: {
+        ...calculatePagination(req.query.page, testimonials.count, resource),
+        testimonials: testimonials.rows,
+      },
     })
   }),
   post: catchAsync(async (req, res) => {

--- a/controllers/testimonial.js
+++ b/controllers/testimonial.js
@@ -15,7 +15,7 @@ module.exports = {
       res,
       code: httpStatus.OK,
       status: true,
-      messege: 'Testimonials found',
+      message: 'Testimonials found',
       body: testimonials,
     })
   }),

--- a/routes/testimonial.js
+++ b/routes/testimonial.js
@@ -3,8 +3,12 @@ const { createTestimonialSchema, updateTestimonialSchema } = require('../schemas
 const { validateSchema } = require('../middlewares/validateErrors')
 const { auth } = require('../middlewares/auth')
 const { isAdmin } = require('../middlewares/isAdmin')
-const { post, destroy, update } = require('../controllers/testimonial')
+const {
+  list, post, destroy, update,
+} = require('../controllers/testimonial')
 const { uploadImage } = require('../middlewares/uploadImage')
+
+router.get('/', auth, list)
 
 router.post('/', auth, isAdmin, validateSchema(createTestimonialSchema), post)
 

--- a/services/testimonial.js
+++ b/services/testimonial.js
@@ -8,6 +8,10 @@ const { uploadImageToS3 } = require('./uploadImageToS3')
 const unlinkFile = util.promisify(fs.unlink)
 
 module.exports = {
+  listTestimonial: async () => {
+    const allTestimonials = await Testimonial.findAll()
+    return allTestimonials
+  },
   /**
    * Create a testimonial
    *

--- a/services/testimonial.js
+++ b/services/testimonial.js
@@ -8,8 +8,12 @@ const { uploadImageToS3 } = require('./uploadImageToS3')
 const unlinkFile = util.promisify(fs.unlink)
 
 module.exports = {
-  listTestimonial: async () => {
-    const allTestimonials = await Testimonial.findAll()
+  listTestimonial: async (page) => {
+    const allTestimonials = await Testimonial.findAll({
+      limit: 10,
+      offset: 10 * (page - 1),
+      order: [['createdAt', 'DESC']],
+    })
     return allTestimonials
   },
   /**

--- a/services/testimonial.js
+++ b/services/testimonial.js
@@ -9,7 +9,7 @@ const unlinkFile = util.promisify(fs.unlink)
 
 module.exports = {
   listTestimonial: async (page) => {
-    const allTestimonials = await Testimonial.findAll({
+    const allTestimonials = await Testimonial.findAndCountAll({
       limit: 10,
       offset: 10 * (page - 1),
       order: [['createdAt', 'DESC']],


### PR DESCRIPTION
[OT198-88](https://alkemy-labs.atlassian.net/jira/software/c/projects/OT198/boards/278?modal=detail&selectedIssue=OT198-88)

## DESCRIPTION

AS user
I WANT to view the results of Paginated Testimonials
TO increase response speed

### Criteria of acceptance:

When the request to list is made, the results should be paginated by 10. In the response, the results and the urls for the previous and next page (if applicable) should be shown. The current page will be obtained from the query parameter ?page

### EVIDENCE

GET /testimonials (empty database) 

<img width="614" alt="listtestimonials with out info - res" src="https://user-images.githubusercontent.com/86156941/173698172-b069c753-4684-482f-a3e7-7ca480a08a63.png">

GET /testimonials

<img width="648" alt="testimonials listed- page1 -res" src="https://user-images.githubusercontent.com/86156941/173698372-2198bbe7-5526-4644-8ace-c9819e5a3091.png">

GET /testimonials (page=2)


<img width="583" alt="Testimonials listed - page2 - res" src="https://user-images.githubusercontent.com/86156941/173698555-0ecbfb17-1ccb-4cce-8580-192b69df286f.png">

