### PR TITLE
[SWAGGER] -  Add Documentation to Testimonials - OT198-93

### DIFF
--- a/constants/roles.js
+++ b/constants/roles.js
@@ -1,0 +1,6 @@
+const Roles = {
+  ADMIN: 1,
+  STANDARD: 2,
+}
+
+module.exports = Roles

--- a/controllers/news.js
+++ b/controllers/news.js
@@ -2,11 +2,27 @@ const { catchAsync } = require('../helpers/catchAsync')
 const { endpointResponse } = require('../helpers/success')
 const httpStatus = require('../helpers/httpStatus')
 const {
-  getNewById, createNew, updateNew, deleteNew,
+  getNewById, createNew, updateNew, deleteNew, listNews,
 } = require('../services/news')
+const { calculatePagination } = require('../utils/pagination')
 
 module.exports = {
   list: catchAsync(async (req, res) => {
+    const resource = req.baseUrl
+    req.query.page = req.query.page || 1
+    const news = await listNews(req.query.page)
+    endpointResponse({
+      res,
+      code: httpStatus.OK,
+      status: true,
+      message: 'successfully retrieved',
+      body: {
+        ...calculatePagination(req.query.page, news.count, resource),
+        members: news.rows,
+      },
+    })
+  }),
+  listNew: catchAsync(async (req, res) => {
     const { id } = req.params
     const result = await getNewById(id)
     endpointResponse({

--- a/controllers/testimonial.js
+++ b/controllers/testimonial.js
@@ -2,12 +2,29 @@ const httpStatus = require('../helpers/httpStatus')
 const { catchAsync } = require('../helpers/catchAsync')
 const { endpointResponse } = require('../helpers/success')
 const {
+  listTestimonial,
   createTestimonial,
   updateTestimonial,
   deleteTestimonial,
 } = require('../services/testimonial')
+const { calculatePagination } = require('../utils/pagination')
 
 module.exports = {
+  list: catchAsync(async (req, res) => {
+    const resource = req.baseUrl
+    req.query.page = req.query.page || 1
+    const testimonials = await listTestimonial(req.query.page)
+    return endpointResponse({
+      res,
+      code: httpStatus.OK,
+      status: true,
+      message: 'Testimonials found',
+      body: {
+        ...calculatePagination(req.query.page, testimonials.count, resource),
+        testimonials: testimonials.rows,
+      },
+    })
+  }),
   post: catchAsync(async (req, res) => {
     const testimonialCreated = await createTestimonial(req)
     return endpointResponse({

--- a/database/seeders/20220607144743-users.js
+++ b/database/seeders/20220607144743-users.js
@@ -1,5 +1,5 @@
 'use strict';
-const bcrypt = require('bcrypt');
+const Roles = require('../../constants/roles')
 
 module.exports = {
   async up(queryInterface, Sequelize) {
@@ -10,7 +10,7 @@ module.exports = {
         email:"ncrook0@yolasite.com", 
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi", 
         photo:"http://dummyimage.com/196x100.png/ff4444/ffffff", 
-        roleId:1, 
+        roleId:Roles.ADMIN, 
         createdAt:new Date(), 
         updatedAt:new Date()
       },
@@ -20,7 +20,7 @@ module.exports = {
         email:"mlabern1@army.mil",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/213x100.png/cc0000/ffffff",
-        roleId:2,
+        roleId:Roles.STANDARD,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -30,7 +30,7 @@ module.exports = {
         email:"uatterbury2@eepurl.com",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/223x100.png/5fa2dd/ffffff",
-        roleId:1,
+        roleId:Roles.ADMIN,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -40,7 +40,7 @@ module.exports = {
         email:"jlabrom3@tumblr.com",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/205x100.png/cc0000/ffffff",
-        roleId:2,
+        roleId:Roles.STANDARD,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -50,7 +50,7 @@ module.exports = {
         email:"ameeks4@gizmodo.com",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/103x100.png/dddddd/000000",
-        roleId:1,
+        roleId:Roles.ADMIN,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -60,7 +60,7 @@ module.exports = {
         email:"agibling5@about.com",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/208x100.png/cc0000/ffffff",
-        roleId:2,
+        roleId:Roles.STANDARD,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -70,7 +70,7 @@ module.exports = {
         email:"mbauldrey6@mayoclinic.com",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/207x100.png/ff4444/ffffff",
-        roleId:1,
+        roleId:Roles.ADMIN,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -80,7 +80,7 @@ module.exports = {
         email:"ceye7@omniture.com",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/207x100.png/cc0000/ffffff",
-        roleId:2,
+        roleId:Roles.STANDARD,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -90,7 +90,7 @@ module.exports = {
         email:"cdevennie8@hugedomains.com",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/131x100.png/5fa2dd/ffffff",
-        roleId:1,
+        roleId:Roles.ADMIN,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -100,7 +100,7 @@ module.exports = {
         email:"kblanchflower9@spiegel.de",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/167x100.png/dddddd/000000",
-        roleId:2,
+        roleId:Roles.STANDARD,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -110,7 +110,7 @@ module.exports = {
         email:"fguidonia@archive.org",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/208x100.png/ff4444/ffffff",
-        roleId:1,
+        roleId:Roles.ADMIN,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -120,7 +120,7 @@ module.exports = {
         email:"jstillertb@eventbrite.com",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/133x100.png/ff4444/ffffff",
-        roleId:2,
+        roleId:Roles.STANDARD,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -130,7 +130,7 @@ module.exports = {
         email:"abonsulc@mac.com",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/113x100.png/dddddd/000000",
-        roleId:1,
+        roleId:Roles.ADMIN,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -140,7 +140,7 @@ module.exports = {
         email:"etookd@youtu.be",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/158x100.png/dddddd/000000",
-        roleId:2,
+        roleId:Roles.STANDARD,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -150,7 +150,7 @@ module.exports = {
         email:"jpartingtone@washington.edu",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/125x100.png/ff4444/ffffff",
-        roleId:1,
+        roleId:Roles.ADMIN,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -160,7 +160,7 @@ module.exports = {
         email:"estichelf@dagondesign.com",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/166x100.png/5fa2dd/ffffff",
-        roleId:2,
+        roleId:Roles.STANDARD,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -170,7 +170,7 @@ module.exports = {
         email:"jgettinsg@epa.gov",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/227x100.png/cc0000/ffffff",
-        roleId:1,
+        roleId:Roles.ADMIN,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -180,7 +180,7 @@ module.exports = {
         email:"sphillpoth@reverbnation.com",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/144x100.png/dddddd/000000",
-        roleId:2,
+        roleId:Roles.STANDARD,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -190,7 +190,7 @@ module.exports = {
         email:"fhorwelli@oracle.com",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/151x100.png/cc0000/ffffff",
-        roleId:1,
+        roleId:Roles.ADMIN,
         createdAt:new Date(),
         updatedAt:new Date()
       },
@@ -200,7 +200,7 @@ module.exports = {
         email:"rwraggsj@state.tx.us",
         password:"$2b$12$MoOasB90mwaKwp5xkbGYauyIPfWh7oBZrYmCDaSG3o.LU.o4vQMZi",
         photo:"http://dummyimage.com/193x100.png/cc0000/ffffff",
-        roleId:2,
+        roleId:Roles.STANDARD,
         createdAt:new Date(),
         updatedAt:new Date()
       }], {});

--- a/middlewares/isAdmin.js
+++ b/middlewares/isAdmin.js
@@ -2,11 +2,12 @@ const ApiError = require('../helpers/ApiError')
 const { catchAsync } = require('../helpers/catchAsync')
 const httpStatus = require('../helpers/httpStatus')
 const { decodeToken } = require('./jwt')
+const Roles = require('../constants/roles')
 
 module.exports = {
   isAdmin: catchAsync(async (req, res, next) => {
     const user = decodeToken(req)
-    if (user.roleId !== 1) {
+    if (user.roleId !== Roles.ADMIN) {
       throw new ApiError(httpStatus.UNAUTHORIZED, 'You are not an admin')
     } else {
       next()

--- a/middlewares/ownership.js
+++ b/middlewares/ownership.js
@@ -1,16 +1,20 @@
 const ApiError = require('../helpers/ApiError')
 const { decodeToken } = require('./jwt')
+const db = require('../database/models/index')
 const httpStatus = require('../helpers/httpStatus')
 const { catchAsync } = require('../helpers/catchAsync')
 const Roles = require('../constants/roles')
 
-module.exports = {
-  ownershipValidate: catchAsync(async (req, res, next) => {
-    const user = decodeToken(req)
-    if (user.roleId === Roles.ADMIN || user.id === +req.params.id) {
-      next()
-    } else {
-      throw new ApiError(httpStatus.FORBIDDEN, 'You are not allowed to do this')
-    }
-  }),
-}
+module.exports = (entity) => catchAsync(async (req, res, next) => {
+  const result = await db[entity].findByPk(req.params.id)
+  if (!result) throw new ApiError(httpStatus.NOT_FOUND, `element of ${entity} with id ${req.params.id} not found`)
+
+  const userId = entity === 'User' ? result.id : result.userId
+  const user = decodeToken(req)
+
+  if (user.roleId === Roles.ADMIN || user.id === userId) {
+    next()
+  } else {
+    throw new ApiError(httpStatus.FORBIDDEN, 'You are not allowed to do this')
+  }
+})

--- a/middlewares/ownership.js
+++ b/middlewares/ownership.js
@@ -2,11 +2,12 @@ const ApiError = require('../helpers/ApiError')
 const { decodeToken } = require('./jwt')
 const httpStatus = require('../helpers/httpStatus')
 const { catchAsync } = require('../helpers/catchAsync')
+const Roles = require('../constants/roles')
 
 module.exports = {
   ownershipValidate: catchAsync(async (req, res, next) => {
     const user = decodeToken(req)
-    if (user.roleId === 1 || user.id === +req.params.id) {
+    if (user.roleId === Roles.ADMIN || user.id === +req.params.id) {
       next()
     } else {
       throw new ApiError(httpStatus.FORBIDDEN, 'You are not allowed to do this')

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -3,15 +3,14 @@ const {
   list, update, post, destroy,
 } = require('../controllers/comments')
 const { auth } = require('../middlewares/auth')
+const ownership = require('../middlewares/ownership')
 const { isAdmin } = require('../middlewares/isAdmin')
 const { validateSchema } = require('../middlewares/validateErrors')
 const { updateCommentSchema, newCommentSchema } = require('../schemas/comment')
 
 router.get('/', auth, isAdmin, list)
 router.post('/', auth, validateSchema(newCommentSchema), post)
-
-router.put('/:id', auth, validateSchema(updateCommentSchema), update)
-// delete comments
-router.delete('/:id', auth, destroy)
+router.put('/:id', auth, ownership('Comment'), validateSchema(updateCommentSchema), update)
+router.delete('/:id', auth, ownership('Comment'), destroy)
 
 module.exports = router

--- a/routes/news.js
+++ b/routes/news.js
@@ -5,13 +5,14 @@ const router = new express.Router()
 const { validateSchema } = require('../middlewares/validateErrors')
 const newSchema = require('../schemas/new')
 const {
-  post, list, update, destroy,
+  post, listNew, update, destroy, list,
 } = require('../controllers/news')
 const { auth } = require('../middlewares/auth')
 const { isAdmin } = require('../middlewares/isAdmin')
 const { listNewsComments } = require('../controllers/comments')
 
-router.get('/:id', list)
+router.get('/', list)
+router.get('/:id', listNew)
 router.post('/', auth, isAdmin, validateSchema(newSchema), post)
 router.put('/:id', auth, isAdmin, validateSchema(newSchema), update)
 router.delete('/:id', auth, isAdmin, destroy)

--- a/routes/testimonial.js
+++ b/routes/testimonial.js
@@ -3,8 +3,12 @@ const { createTestimonialSchema, updateTestimonialSchema } = require('../schemas
 const { validateSchema } = require('../middlewares/validateErrors')
 const { auth } = require('../middlewares/auth')
 const { isAdmin } = require('../middlewares/isAdmin')
-const { post, destroy, update } = require('../controllers/testimonial')
+const {
+  list, post, destroy, update,
+} = require('../controllers/testimonial')
 const { uploadImage } = require('../middlewares/uploadImage')
+
+router.get('/', auth, list)
 
 router.post('/', auth, isAdmin, validateSchema(createTestimonialSchema), post)
 

--- a/routes/testimonial.js
+++ b/routes/testimonial.js
@@ -10,8 +10,228 @@ const { uploadImage } = require('../middlewares/uploadImage')
 
 router.get('/', auth, list)
 
-router.post('/', auth, isAdmin, validateSchema(createTestimonialSchema), post)
+// Define testimonial schemas
+/**
+ * @swagger
+ * components:
+ *   securitySchemes:
+ *     bearerAuth:
+ *       type: http
+ *       scheme: bearer
+ *       in: header
+ *       name: Authorization
+ *   schemas:
+ *     Testimonial:
+ *       type: object
+ *       properties:
+ *         name:
+ *           type: string
+ *           format: string
+ *           example: "John Doe"
+ *         image:
+ *          type: string
+ *          format: string
+ *          example: "https://example.com/image.png"
+ *         content:
+ *           type: string
+ *           format: string
+ *           example: "This is a testimonial"
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *           example: "2020-01-01T00:00:00.000Z"
+ *         updatedAt:
+ *           type: string
+ *           format: date-time
+ *           example: "2020-01-01T00:00:00.000Z"
+ *         deletedAt:
+ *           type: string
+ *           format: date-time
+ *           example: null
+ */
 
+// Define testimonial tags
+/**
+ * @swagger
+ * tags:
+ *   name: Testimonials
+ *   description: The testimonials API
+ */
+
+// Document routes
+/**
+ * @swagger
+ * /testimonials:
+ *   post:
+ *     summary: Create a new testimonial
+ *     tags: [Testimonials]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *        multipart/form-data:
+ *         schema:
+ *          type: object
+ *          properties:
+ *           image:
+ *            type: string
+ *            format: binary
+ *            required: true
+ *           name:
+ *            type: string
+ *            required: true
+ *           content:
+ *            type: string
+ *            required: true
+ *     security:
+ *      - bearerAuth: {}
+ *     responses:
+ *       201:
+ *         description: Testimonial created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: boolean
+ *                   format: boolean
+ *                 message:
+ *                   type: string
+ *                   format: string
+ *                 body:
+ *                   $ref: '#/components/schemas/Testimonial'
+ *       400:
+ *        description: Bad request
+ *        content:
+ *          application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               code:
+ *                type: integer
+ *                description: The error code
+ *               status:
+ *                   type: boolean
+ *                   description: The status of the response
+ *               message:
+ *                   type: string
+ *                   description: The message of the response
+ *             example:
+ *              code: 400
+ *              status: false
+ *              message: "Testimonial not created"
+ *       500:
+ *        description: Internal server error
+ *        content:
+ *          application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               code:
+ *                type: integer
+ *                description: The error code
+ *               status:
+ *                   type: boolean
+ *                   description: The status of the response
+ *               message:
+ *                   type: string
+ *                   description: The message of the response
+ *             example:
+ *              code: 500
+ *              status: false
+ *              message: "Internal server error"
+ */
+router.post('/', auth, isAdmin, uploadImage('image'), validateSchema(createTestimonialSchema), post)
+
+/**
+ * @swagger
+ * /testimonials/{id}:
+ *   put:
+ *     summary: Update a testimonial
+ *     tags: [Testimonials]
+ *     parameters:
+ *      - in: path
+ *        name: id
+ *        schema:
+ *          type: integer
+ *        required: true
+ *        description: The testimonial id
+ *     requestBody:
+ *       required: true
+ *       content:
+ *        multipart/form-data:
+ *         schema:
+ *          type: object
+ *          properties:
+ *           image:
+ *            type: string
+ *            format: binary
+ *            required: true
+ *           name:
+ *            type: string
+ *            required: true
+ *           content:
+ *            type: string
+ *            required: true
+ *     security:
+ *      - bearerAuth: {}
+ *     responses:
+ *       200:
+ *         description: Testimonial updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: boolean
+ *                   format: boolean
+ *                 message:
+ *                   type: string
+ *                   format: string
+ *                 body:
+ *                   $ref: '#/components/schemas/Testimonial'
+ *       500:
+ *        description: Internal server error
+ *        content:
+ *          application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               code:
+ *                type: integer
+ *                description: The error code
+ *               status:
+ *                   type: boolean
+ *                   description: The status of the response
+ *               message:
+ *                   type: string
+ *                   description: The message of the response
+ *             example:
+ *              code: 500
+ *              status: false
+ *              message: "Internal server error"
+ *       404:
+ *        description: Testimonial not found
+ *        content:
+ *          application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               code:
+ *                type: integer
+ *                description: The error code
+ *               status:
+ *                   type: boolean
+ *                   description: The status of the response
+ *               message:
+ *                   type: string
+ *                   description: The message of the response
+ *             example:
+ *              code: 404
+ *              status: false
+ *              message: "Testimonial with id 1 not found"
+ */
 router.put(
   '/:id',
   auth,
@@ -21,8 +241,53 @@ router.put(
   update,
 )
 
-router.post('/', auth, isAdmin, uploadImage('image'), validateSchema(createTestimonialSchema), post)
-
+/**
+ * @swagger
+ * /testimonials/{id}:
+ *   delete:
+ *     summary: Delete a testimonial
+ *     tags: [Testimonials]
+ *     parameters:
+ *      - in: path
+ *        name: id
+ *        schema:
+ *          type: integer
+ *        required: true
+ *        description: The testimonial id
+ *     security:
+ *      - bearerAuth: {}
+ *     responses:
+ *      200:
+ *        description: Testimonial deleted successfully
+ *        content:
+ *          application/json:
+ *             schema:
+ *                type: object
+ *                example:
+ *                   code: 200
+ *                   status: true
+ *                   message: "Testimonial deleted successfully"
+ *      500:
+ *        description: Internal server error
+ *        content:
+ *          application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               code:
+ *                type: integer
+ *                description: The error code
+ *               status:
+ *                   type: boolean
+ *                   description: The status of the response
+ *               message:
+ *                   type: string
+ *                   description: The message of the response
+ *             example:
+ *              code: 500
+ *              status: false
+ *              message: "Internal server error"
+ */
 router.delete('/:id', auth, isAdmin, destroy)
 
 module.exports = router

--- a/schemas/testimonial.js
+++ b/schemas/testimonial.js
@@ -18,11 +18,13 @@ module.exports = {
       .withMessage('required'),
   ],
   updateTestimonialSchema: [
-    body('name').isString().withMessage('must be a string').trim()
+    body('name').notEmpty().isString().withMessage('must be a string')
+      .trim()
       .optional(),
     body('image').isString().withMessage('must be a string').trim()
       .optional(),
-    body('content').isString().withMessage('must be a string').trim()
+    body('content').notEmpty().isString().withMessage('must be a string')
+      .trim()
       .optional(),
   ],
 }

--- a/services/comments.js
+++ b/services/comments.js
@@ -1,8 +1,6 @@
 const { Comment, User, New } = require('../database/models')
 const ApiError = require('../helpers/ApiError')
 const httpStatus = require('../helpers/httpStatus')
-const { decodeToken } = require('../middlewares/jwt')
-const Roles = require('../constants/roles')
 
 module.exports = {
   listComments: async () => {
@@ -76,27 +74,19 @@ module.exports = {
   },
   updateComment: async (req) => {
     const comment = await Comment.findByPk(req.params.id)
-    const user = decodeToken(req)
     if (!comment) {
       throw new ApiError(httpStatus.NOT_FOUND, 'Comment not found')
-    }
-    if (user.roleId !== Roles.ADMIN && user.id !== comment.userId) {
-      throw new ApiError(httpStatus.UNAUTHORIZED, 'Unauthorized')
     }
     comment.body = req.body.body
     await comment.save()
     return comment
   },
-  deleteComment: async (id, req) => {
+  deleteComment: async (id) => {
     const comment = await Comment.findByPk(id)
     if (!comment) {
       throw new ApiError(httpStatus.NOT_FOUND, 'Comment not found')
     }
-    const user = decodeToken(req)
-    if (user.roleId === Roles.ADMIN || user.id === comment.userId) {
-      await comment.destroy()
-      return true
-    }
-    throw new ApiError(httpStatus.FORBIDDEN, 'You are not allowed to do this')
+    await comment.destroy()
+    return true
   },
 }

--- a/services/comments.js
+++ b/services/comments.js
@@ -2,6 +2,7 @@ const { Comment, User, New } = require('../database/models')
 const ApiError = require('../helpers/ApiError')
 const httpStatus = require('../helpers/httpStatus')
 const { decodeToken } = require('../middlewares/jwt')
+const Roles = require('../constants/roles')
 
 module.exports = {
   listComments: async () => {
@@ -73,14 +74,13 @@ module.exports = {
     const comment = await Comment.create(body)
     return comment
   },
-
   updateComment: async (req) => {
     const comment = await Comment.findByPk(req.params.id)
     const user = decodeToken(req)
     if (!comment) {
       throw new ApiError(httpStatus.NOT_FOUND, 'Comment not found')
     }
-    if (user.roleId !== 1 && user.id !== comment.userId) {
+    if (user.roleId !== Roles.ADMIN && user.id !== comment.userId) {
       throw new ApiError(httpStatus.UNAUTHORIZED, 'Unauthorized')
     }
     comment.body = req.body.body
@@ -93,7 +93,7 @@ module.exports = {
       throw new ApiError(httpStatus.NOT_FOUND, 'Comment not found')
     }
     const user = decodeToken(req)
-    if (user.roleId === 1 || user.id === comment.userId) {
+    if (user.roleId === Roles.ADMIN || user.id === comment.userId) {
       await comment.destroy()
       return true
     }

--- a/services/news.js
+++ b/services/news.js
@@ -3,6 +3,14 @@ const ApiError = require('../helpers/ApiError')
 const httpStatus = require('../helpers/httpStatus')
 
 module.exports = {
+  listNews: async (page) => {
+    const allNews = await New.findAndCountAll({
+      limit: 10,
+      offset: 10 * (page - 1),
+      order: [['createdAt', 'DESC']],
+    })
+    return allNews
+  },
   getNewById: async (id) => {
     const result = await New.findByPk(id)
     if (!result) throw new ApiError(httpStatus.NOT_FOUND, 'New not found')

--- a/services/testimonial.js
+++ b/services/testimonial.js
@@ -8,6 +8,14 @@ const { uploadImageToS3 } = require('./uploadImageToS3')
 const unlinkFile = util.promisify(fs.unlink)
 
 module.exports = {
+  listTestimonial: async (page) => {
+    const allTestimonials = await Testimonial.findAndCountAll({
+      limit: 10,
+      offset: 10 * (page - 1),
+      order: [['createdAt', 'DESC']],
+    })
+    return allTestimonials
+  },
   /**
    * Create a testimonial
    *

--- a/services/user.js
+++ b/services/user.js
@@ -4,6 +4,7 @@ const { sendWelcomeEmail } = require('./sendgrid')
 const ApiError = require('../helpers/ApiError')
 const { generateToken } = require('../middlewares/jwt')
 const httpStatus = require('../helpers/httpStatus')
+const Roles = require('../constants/roles')
 
 module.exports = {
   createUser: async (data) => {
@@ -17,6 +18,7 @@ module.exports = {
         lastName,
         email,
         password: bcrypt.hashSync(password, 12),
+        roleId: Roles.STANDARD,
       },
     })
     if (!created) throw new ApiError(httpStatus.CONFLICT, 'Email already exists')

--- a/utils/pagination.js
+++ b/utils/pagination.js
@@ -1,6 +1,8 @@
+const port = process.env.PORT || 3000
+
 const baseURL = process.env.BASE_URL
   ? `${process.env.BASE_URL}`
-  : 'http://localhost:3000'
+  : `http://localhost:${port}`
 
 const stringPage = '?page='
 


### PR DESCRIPTION
[OT198-93](https://alkemy-labs.atlassian.net/browse/OT198-93)
Description

AS a developer
I WANT to have a documentation of the testimonials endpoints
TO have references of its operation

Criteria of acceptance:
The different endpoints must be documented, specifying the data model, mandatory fields, request format and its example.

## Evidence
- Swagger view
![image](https://user-images.githubusercontent.com/88128116/173851303-275c34d1-c5e0-4757-83d5-36504194c08c.png)
- PUT /testimonials example body
![image](https://user-images.githubusercontent.com/88128116/173851520-e5510d20-3dba-41b5-b10c-6e0b38b52c9f.png)
- PUT /testimonials example responses
![image](https://user-images.githubusercontent.com/88128116/173851642-3870f43b-1fd4-4340-b44e-f661ff4faa8c.png)
- Testimonial create and update schema
![image](https://user-images.githubusercontent.com/88128116/173860606-b2777d44-aea5-42a6-9fdc-7f17cbd9e0b2.png)


