### PR TITLE
[ FIX ] OT198-FIX-OWNERSHIP Fix Ownership Middleware

### DIFF
--- a/middlewares/ownership.js
+++ b/middlewares/ownership.js
@@ -1,15 +1,19 @@
 const ApiError = require('../helpers/ApiError')
 const { decodeToken } = require('./jwt')
+const db = require('../database/models/index')
 const httpStatus = require('../helpers/httpStatus')
 const { catchAsync } = require('../helpers/catchAsync')
 
-module.exports = {
-  ownershipValidate: catchAsync(async (req, res, next) => {
-    const user = decodeToken(req)
-    if (user.roleId === 1 || user.id === +req.params.id) {
-      next()
-    } else {
-      throw new ApiError(httpStatus.FORBIDDEN, 'You are not allowed to do this')
-    }
-  }),
-}
+module.exports = (entity) => catchAsync(async (req, res, next) => {
+  const result = await db[entity].findByPk(req.params.id)
+  if (!result) throw new ApiError(httpStatus.NOT_FOUND, `element of ${entity} with id ${req.params.id} not found`)
+
+  const userId = entity === 'User' ? result.id : result.userId
+  const user = decodeToken(req)
+
+  if (user.roleId === 1 || user.id === userId) {
+    next()
+  } else {
+    throw new ApiError(httpStatus.FORBIDDEN, 'You are not allowed to do this')
+  }
+})

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -3,15 +3,14 @@ const {
   list, update, post, destroy,
 } = require('../controllers/comments')
 const { auth } = require('../middlewares/auth')
+const ownership = require('../middlewares/ownership')
 const { isAdmin } = require('../middlewares/isAdmin')
 const { validateSchema } = require('../middlewares/validateErrors')
 const { updateCommentSchema, newCommentSchema } = require('../schemas/comment')
 
 router.get('/', auth, isAdmin, list)
 router.post('/', auth, validateSchema(newCommentSchema), post)
-
-router.put('/:id', auth, validateSchema(updateCommentSchema), update)
-// delete comments
-router.delete('/:id', auth, destroy)
+router.put('/:id', auth, ownership('Comment'), validateSchema(updateCommentSchema), update)
+router.delete('/:id', auth, ownership('Comment'), destroy)
 
 module.exports = router

--- a/services/comments.js
+++ b/services/comments.js
@@ -1,7 +1,7 @@
 const { Comment, User, New } = require('../database/models')
 const ApiError = require('../helpers/ApiError')
 const httpStatus = require('../helpers/httpStatus')
-const { decodeToken } = require('../middlewares/jwt')
+/* const { decodeToken } = require('../middlewares/jwt') */
 
 module.exports = {
   listComments: async () => {
@@ -73,30 +73,21 @@ module.exports = {
     const comment = await Comment.create(body)
     return comment
   },
-
   updateComment: async (req) => {
     const comment = await Comment.findByPk(req.params.id)
-    const user = decodeToken(req)
     if (!comment) {
       throw new ApiError(httpStatus.NOT_FOUND, 'Comment not found')
-    }
-    if (user.roleId !== 1 && user.id !== comment.userId) {
-      throw new ApiError(httpStatus.UNAUTHORIZED, 'Unauthorized')
     }
     comment.body = req.body.body
     await comment.save()
     return comment
   },
-  deleteComment: async (id, req) => {
+  deleteComment: async (id) => {
     const comment = await Comment.findByPk(id)
     if (!comment) {
       throw new ApiError(httpStatus.NOT_FOUND, 'Comment not found')
     }
-    const user = decodeToken(req)
-    if (user.roleId === 1 || user.id === comment.userId) {
-      await comment.destroy()
-      return true
-    }
-    throw new ApiError(httpStatus.FORBIDDEN, 'You are not allowed to do this')
+    await comment.destroy()
+    return true
   },
 }


### PR DESCRIPTION
## Description

- Fix ownership middleware. Made a dynamic function that look the entity's owner and compare with the user id into de token.
- Add ownership middleware into the PUT and DELETE comments routes.
- Refactor UPDATE and DELETE comments service.

## Evidence

- Comment deleted
![Screenshot_12](https://user-images.githubusercontent.com/72532638/173911680-1c2bb067-e89d-4b1b-b0f6-fdfc0a126701.png)

- Comment edited by owner
![Screenshot_11](https://user-images.githubusercontent.com/72532638/173911786-c2bf2d57-52d2-4c9e-85c9-c959b4a1ae62.png)

- Comment edited by admin
![Screenshot_9](https://user-images.githubusercontent.com/72532638/173912093-51261488-1fb7-4545-929c-5fbb27b49a10.png)

- Error: User not allowed
![Screenshot_8](https://user-images.githubusercontent.com/72532638/173912357-0ff90eae-2096-4297-85a5-4eee6c45bc98.png)

