### PR TITLE
[SWAGGER] OT198-94 Add auth documentation

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -4,13 +4,204 @@ const { validateSchema } = require('../middlewares/validateErrors')
 const { post, login, userDataByToken } = require('../controllers/user')
 const { auth } = require('../middlewares/auth')
 
-// register new user
+// Define Auth schemas
+/**
+ * @swagger
+ * components:
+ *  securitySchemes:
+ *   bearerAuth:
+ *    type: http
+ *    scheme: bearer
+ *    bearerFormat: JWT
+ *    in: header
+ *    name: Authorization
+ *    description: Bearer token
+ *    required: true
+ */
+
+// Define testimonial tags
+/**
+ * @swagger
+ * tags:
+ *  name: Auth
+ *  description: Auth routes
+ */
+
+/**
+ * @swagger
+ * /auth/register:
+ *  post:
+ *   tags:
+ *   - Auth
+ *   summary: Register a new user
+ *   description: Register a new user
+ *   parameters:
+ *    - name: body
+ *      in: body
+ *      description: User data
+ *      required: true
+ *      schema:
+ *       type: object
+ *       required:
+ *        - firstName
+ *        - lastName
+ *        - email
+ *        - password
+ *       properties:
+ *        firstName:
+ *         type: string
+ *        lastName:
+ *         type: string
+ *        email:
+ *         type: string
+ *         format: email
+ *        password:
+ *         type: string
+ *         format: password
+ *   responses:
+ *     '200':
+ *      description: User created
+ *      content:
+ *       application/json:
+ *        schema:
+ *         type: object
+ *         properties:
+ *          status:
+ *           type: boolean
+ *          message:
+ *           type: string
+ *          body:
+ *           type: object
+ *           properties:
+ *            userToken:
+ *             type: string
+ *         example:
+ *          status: true
+ *          message: User created
+ *          body:
+ *           userToker: 123123131223123123
+ */
 router.post('/register', validateSchema(userRegisterSchema), post)
 
 // login user
+/**
+ * @swagger
+ * /auth/login:
+ *  post:
+ *   tags:
+ *   - Auth
+ *   summary: Login a user
+ *   description: Login a user
+ *   parameters:
+ *    - name: body
+ *      in: body
+ *      description: User data
+ *      required: true
+ *      schema:
+ *       type: object
+ *       required:
+ *        - email
+ *        - password
+ *       properties:
+ *        email:
+ *         type: string
+ *         format: email
+ *        password:
+ *         type: string
+ *         format: password
+ *   responses:
+ *    '200':
+ *     description: User logged in
+ *     content:
+ *      application/json:
+ *       schema:
+ *        type: object
+ *        properties:
+ *          status:
+ *           type: boolean
+ *          message:
+ *           type: string
+ *          body:
+ *           type: object
+ *           properties:
+ *            user:
+ *             type: object
+ *             properties:
+ *              id:
+ *               type: string
+ *              firstName:
+ *               type: string
+ *              lastName:
+ *               type: string
+ *              email:
+ *               type: string
+ *              password:
+ *               type: string
+ *              createdAt:
+ *               type: string
+ *              updatedAt:
+ *               type: string
+ *            token:
+ *             type: string
+ *             format: jwt
+ *        example:
+ *         status: true,
+ *         message: User logged in,
+ *         body:
+ *          user:
+ *           id: 1
+ *           firstName: John
+ *           lastName: Doe
+ *           email: example@asd.com
+ *           password: password
+ *           createdAt: '2020-01-01T00:00:00.000Z'
+ *           updatedAt: '2020-01-01T00:00:00.000Z'
+ *          token: 123123123123123123s
+ */
 router.post('/login', validateSchema(userLoginSchema), login)
 
 // authenticated user data
+/**
+ * @swagger
+ * /auth/me:
+ *  get:
+ *   tags:
+ *   - Auth
+ *   summary: Get authenticated user data
+ *   description: Get authenticated user data
+ *   security:
+ *    - bearerAuth: {}
+ *   responses:
+ *    '200':
+ *     description: User data
+ *     content:
+ *      application/json:
+ *       schema:
+ *        type: object
+ *        properties:
+ *         status:
+ *          type: boolean
+ *         message:
+ *          type: string
+ *         body:
+ *          type: object
+ *          properties:
+ *           user:
+ *            type: object
+ *            properties:
+ *             id:
+ *              type: string
+ *             firstName:
+ *              type: string
+ *             lastName:
+ *              type: string
+ *             email:
+ *              type: string
+ *             createdAt:
+ *              type: string
+ *             updatedAt:
+ *              type: string
+ */
 router.get('/me', auth, userDataByToken)
 
 module.exports = router


### PR DESCRIPTION
[OT198-94](https://alkemy-labs.atlassian.net/browse/OT198-94)

AS a developer
I WANT to have a documentation of the authentication endpoints
TO have references of its operation

Criteria of acceptance:
The different endpoints must be documented, specifying the data model, mandatory fields, request format and its example.

Evidence
![image](https://user-images.githubusercontent.com/81152540/174073513-4be337cc-72c4-466b-860d-287921e69551.png)
![image](https://user-images.githubusercontent.com/81152540/174073577-70b5b408-612b-4cff-bbda-e5b919a9469e.png)
![image](https://user-images.githubusercontent.com/81152540/174073611-d768975a-8f7d-4eae-8f7c-26b2008ea603.png)
![image](https://user-images.githubusercontent.com/81152540/174073659-c459ee02-2244-4e06-b3dd-7db5be9a5f78.png)
![image](https://user-images.githubusercontent.com/81152540/174073724-995316a5-c518-46a1-859b-e254f45c1293.png)


