### PR TITLE
add documentation news

### DIFF
--- a/routes/news.js
+++ b/routes/news.js
@@ -12,13 +12,311 @@ const { isAdmin } = require('../middlewares/isAdmin')
 const { listNewsComments } = require('../controllers/comments')
 const { uploadImage } = require('../middlewares/uploadImage')
 
-router.get('/', list)
-router.get('/:id', listNew)
-router.post('/', auth, isAdmin, uploadImage('image'), validateSchema(newSchema), post)
-router.put('/:id', auth, isAdmin, uploadImage('image'), validateSchema(newSchema), update)
-router.delete('/:id', auth, isAdmin, destroy)
+// Define news schemas
+/**
+ * @swagger
+ * components:
+ *   securitySchemes:
+ *     bearerAuth:
+ *       type: http
+ *       scheme: bearer
+ *       in: header
+ *       name: Authorization
+ *   schemas:
+ *     News:
+ *       type: object
+ *       properties:
+ *         name:
+ *           type: string
+ *           format: string
+ *           required: true
+ *         content:
+ *          type: string
+ *          format: string
+ *          required: true
+ *         image:
+ *           type: string
+ *           format: string
+ *           required: true
+ *         type:
+ *           type: string
+ *           format: string
+ *           required: true
+ *         categoryId:
+ *           type: integer
+ *           format: integer
+ *           required: true
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *         updatedAt:
+ *           type: string
+ *           format: date-time
+ *         deletedAt:
+ *           type: string
+ *           format: date-time
+ */
 
+// Define news tags
+/**
+* @swagger
+* tags:
+*   name: News
+*   description: The news API
+*/
+
+// list all News
+/**
+ * @swagger
+ * /news:
+ *   get:
+ *     tags: [News]
+ *     summary: Get a listing of the News.
+ *     description: Get all news
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: boolean
+ *                   format: boolean
+ *                 message:
+ *                   type: string
+ *                   format: string
+ *                 body:
+ *                   type: object
+ *                   properties:
+ *                     name:
+ *                       type: string
+ *                       format: string
+ *                     content:
+ *                       type: string
+ *                       format: string
+ *                     image:
+ *                       type: file
+ *                       format: binary
+ *                     type:
+ *                       type: string
+ *                       format: string
+ *                     categoryId:
+ *                       type: integer
+ *                       format: integer
+ */
+router.get('/', list)
+// list category by id
+/**
+ * @swagger
+ * /news/{id}:
+ *   get:
+ *     tags: [News]
+ *     summary: Display the specified News
+ *     description: Get a specific news
+ *     parameters:
+ *      - in: path
+ *        name: id
+ *        schema:
+ *          type: integer
+ *        required: true
+ *        description: The news id number
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: boolean
+ *                   format: boolean
+ *                 message:
+ *                   type: string
+ *                   format: string
+ *                 body:
+ *                   $ref: '#/components/schemas/News'
+ */
+router.get('/:id', listNew)
+/**
+ * @swagger
+ * /news:
+ *   post:
+ *     tags: [News]
+ *     summary: Create news
+ *     description: Create news
+ *     requestBody:
+ *       required: true
+ *       content:
+ *        multipart/form-data:
+ *         schema:
+ *          type: object
+ *          properties:
+ *           name:
+ *            type: string
+ *            required: true
+ *           content:
+ *            type: string
+ *            required: true
+ *           image:
+ *            type: file
+ *            format: binary
+ *            required: true
+ *           type:
+ *            type: string
+ *            required: true
+ *           categoryId:
+ *            type: integer
+ *            required: true
+ *     security:
+ *      - bearerAuth: {}
+ *     responses:
+ *       201:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: boolean
+ *                   format: boolean
+ *                 message:
+ *                   type: string
+ *                   format: string
+ *                 body:
+ *                   $ref: '#/components/schemas/News'
+ */
+router.post('/', auth, isAdmin, uploadImage('image'), validateSchema(newSchema), post)
+/**
+ * @swagger
+ * /news/{id}:
+ *   put:
+ *     tags: [News]
+ *     summary: Update news
+ *     description: Update news
+ *     requestBody:
+ *       required: true
+ *       content:
+ *        multipart/form-data:
+ *         schema:
+ *          type: object
+ *          properties:
+ *           name:
+ *            type: string
+ *            required: true
+ *           description:
+ *            type: string
+ *            required: false
+ *           image:
+ *            type: file
+ *            format: binary
+ *            required: false
+ *           type:
+ *            type: string
+ *            required: false
+ *           categoryId:
+ *            type: integer
+ *            required: false
+ *     parameters:
+ *      - in: path
+ *        name: id
+ *        schema:
+ *          type: integer
+ *        required: true
+ *        description: The news id number
+ *     security:
+ *      - bearerAuth: {}
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: boolean
+ *                   format: boolean
+ *                 message:
+ *                   type: string
+ *                   format: string
+ *                 body:
+ *                   $ref: '#/components/schemas/News'
+ */
+router.put('/:id', auth, isAdmin, uploadImage('image'), validateSchema(newSchema), update)
+/**
+ * @swagger
+ * /news/{id}:
+ *   delete:
+ *     tags: [News]
+ *     summary: Remove the specified News
+ *     description: Destroy a specific News
+ *     parameters:
+ *      - in: path
+ *        name: id
+ *        schema:
+ *          type: integer
+ *        required: true
+ *        description: The news id number
+ *     security:
+ *      - bearerAuth: {}
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: boolean
+ *                   format: boolean
+ *                 message:
+ *                   type: string
+ *                   format: string
+ */
+router.delete('/:id', auth, isAdmin, destroy)
 // get news comments
+/**
+ * @swagger
+ * /{id}/comments:
+ *   get:
+ *     tags: [News]
+ *     summary: show the specific comments
+ *     description: Get a specific comments
+ *     parameters:
+ *      - in: path
+ *        name: id
+ *        schema:
+ *          type: integer
+ *        required: true
+ *        description: The comments id number
+ *     security:
+ *      - bearerAuth: {}
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: boolean
+ *                   format: boolean
+ *                 message:
+ *                   type: string
+ *                   format: string
+ *                 body:
+ *                   type: object
+ *                   properties:
+ *                     comments:
+ *                       type: string
+ *                       format: string
+ */
 router.get('/:id/comments', auth, listNewsComments)
 
 module.exports = router

--- a/schemas/new.js
+++ b/schemas/new.js
@@ -20,6 +20,12 @@ module.exports = {
       .trim()
       .notEmpty()
       .withMessage('required'),
+    body('type')
+      .isString()
+      .withMessage('must be a string')
+      .trim()
+      .notEmpty()
+      .withMessage('required'),
     body('categoryId')
       .toInt()
       .isInt({ min: 1 })


### PR DESCRIPTION
Descripción

COMO desarrollador
QUIERO disponer de una documentación de los endpoints de Novedades
PARA tener referencias de su funcionamiento

Criterios de aceptación:
Se deberán documentar los diferentes endpoints especificando el modelo de datos, campos obligatorios, formato de la petición y ejemplo de la misma.
get news
![get news](https://user-images.githubusercontent.com/88246144/174691420-d726ab14-89e1-4873-8dad-97da0ef9c012.jpg)
post news
![post news](https://user-images.githubusercontent.com/88246144/174691441-af2f331e-5c9f-49b5-b19b-6337b57ee8ae.jpg)
get news by id
![get news id](https://user-images.githubusercontent.com/88246144/174691455-92ee30d4-bd5f-4ea8-a976-d75041a66d0c.jpg)
put news
![put news id](https://user-images.githubusercontent.com/88246144/174691482-ff90c6ce-b022-4e0b-8945-891726a29bdc.jpg)
delete news
![delete news](https://user-images.githubusercontent.com/88246144/174691495-46304f7f-acea-49f1-8ef1-171f66d27fd8.jpg)
get comments by id
![get id comments](https://user-images.githubusercontent.com/88246144/174691516-1d5a2281-2d32-458f-a5ce-6cb5408f5c5f.jpg)
